### PR TITLE
Fix pedigree zoom gap inconsistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,13 +507,16 @@
       const deltaTop = targetTop - cTop;
       const deltaBot = targetBot - cBot;
 
-      topKid.style.transform = `translateY(${baseTop + Math.round(deltaTop)}px)`;
-      botKid.style.transform = `translateY(${baseBot + Math.round(deltaBot)}px)`;
+      // kompenzuj skaliranje: translateY je u content prostoru, a delta je u ekranskim pikselima
+      const scale = Z.scale || 1;
+      topKid.style.transform = `translateY(${baseTop + Math.round(deltaTop / scale)}px)`;
+      botKid.style.transform = `translateY(${baseBot + Math.round(deltaBot / scale)}px)`;
     }else{
       const mid = (cTop + cBot)/2;
       const delta = (parentC - mid);
-      topKid.style.transform = `translateY(${baseTop + Math.round(delta)}px)`;
-      botKid.style.transform = `translateY(${baseBot + Math.round(delta)}px)`;
+      const scale = Z.scale || 1;
+      topKid.style.transform = `translateY(${baseTop + Math.round(delta / scale)}px)`;
+      botKid.style.transform = `translateY(${baseBot + Math.round(delta / scale)}px)`;
     }
   }
   function padSlideForTransforms(slide){
@@ -527,8 +530,10 @@
 
     const baseTop = 16 + (CFG.gen[Number(slide.id.replace('gen-',''))]?.padTop||0);
     const baseBot = 16 + (CFG.gen[Number(slide.id.replace('gen-',''))]?.padBottom||0);
-    slide.style.paddingTop    = `${baseTop + needTop}px`;
-    slide.style.paddingBottom = `${baseBot + needBot}px`;
+    // kompenzuj skaliranje: padding se primenjuje u content prostoru
+    const scale = Z.scale || 1;
+    slide.style.paddingTop    = `${baseTop + Math.round(needTop / scale)}px`;
+    slide.style.paddingBottom = `${baseBot + Math.round(needBot / scale)}px`;
   }
   function applyGenerationStylingFromCFG(){
     Object.entries(CFG.gen).forEach(([g, conf])=>{


### PR DESCRIPTION
Compensate for zoom scaling in pedigree alignment and padding calculations to maintain a consistent vertical gap between parent pairs.

The existing implementation caused the vertical spacing between parent pairs in the pedigree component to change when the user zoomed in or out. This PR divides translation deltas and padding values by the current zoom scale (`Z.scale`) to ensure that the perceived vertical gap remains constant regardless of the zoom level.

---
<a href="https://cursor.com/background-agent?bcId=bc-40be402a-43bd-440c-87c3-e4f68867d335">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40be402a-43bd-440c-87c3-e4f68867d335">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

